### PR TITLE
Branching refactor

### DIFF
--- a/sierra2mlir/src/compiler/helpers/mod.rs
+++ b/sierra2mlir/src/compiler/helpers/mod.rs
@@ -1,4 +1,5 @@
 pub mod array;
 pub mod maths;
+pub mod nullable;
 pub mod panic;
 pub mod sierra_enum;

--- a/sierra2mlir/src/compiler/helpers/nullable.rs
+++ b/sierra2mlir/src/compiler/helpers/nullable.rs
@@ -1,0 +1,63 @@
+use crate::{
+    compiler::{fn_attributes::FnAttributes, Compiler, Storage},
+    sierra_type::SierraType,
+};
+use color_eyre::Result;
+
+impl<'ctx> Compiler<'ctx> {
+    pub fn create_nullable_is_null(
+        &'ctx self,
+        nullable_type: &SierraType,
+        storage: &mut Storage<'ctx>,
+    ) -> Result<String> {
+        let func_name =
+            format!("nullable_is_null<{}>", nullable_type.get_field_types().unwrap()[0]);
+
+        if storage.helperfuncs.contains(&func_name) {
+            return Ok(func_name);
+        }
+
+        let block = self.new_block(&[nullable_type.get_type()]);
+        let nullable_value = block.argument(0)?.into();
+        let is_null_op = self.op_llvm_extractvalue(&block, 1, nullable_value, self.bool_type())?;
+        let is_null = is_null_op.result(0)?.into();
+        self.op_return(&block, &[is_null]);
+
+        self.create_function(
+            &func_name,
+            vec![block],
+            &[self.bool_type()],
+            FnAttributes::libfunc(false, true),
+        )?;
+
+        Ok(func_name)
+    }
+
+    pub fn create_nullable_unwrap_unsafe(
+        &'ctx self,
+        nullable_type: &SierraType,
+        storage: &mut Storage<'ctx>,
+    ) -> Result<String> {
+        let wrapped_type = nullable_type.get_field_types().unwrap()[0];
+        let func_name = format!("nullable_unwrap_unsafe<{}>", wrapped_type);
+
+        if storage.helperfuncs.contains(&func_name) {
+            return Ok(func_name);
+        }
+
+        let block = self.new_block(&[nullable_type.get_type()]);
+        let nullable_value = block.argument(0)?.into();
+        let is_null_op = self.op_llvm_extractvalue(&block, 0, nullable_value, wrapped_type)?;
+        let is_null = is_null_op.result(0)?.into();
+        self.op_return(&block, &[is_null]);
+
+        self.create_function(
+            &func_name,
+            vec![block],
+            &[wrapped_type],
+            FnAttributes::libfunc(false, true),
+        )?;
+
+        Ok(func_name)
+    }
+}

--- a/sierra2mlir/src/compiler/helpers/sierra_enum.rs
+++ b/sierra2mlir/src/compiler/helpers/sierra_enum.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 
 impl<'ctx> Compiler<'ctx> {
-    fn create_enum_get_tag(
+    pub fn create_enum_get_tag(
         &'ctx self,
         enum_type: &SierraType,
         storage: &mut Storage<'ctx>,
@@ -53,7 +53,7 @@ impl<'ctx> Compiler<'ctx> {
         Ok(func_name)
     }
 
-    fn create_enum_get_data_as_variant_type(
+    pub fn create_enum_get_data_as_variant_type(
         &'ctx self,
         enum_name: &str,
         enum_type: &SierraType,

--- a/sierra2mlir/src/compiler/mlir_ops.rs
+++ b/sierra2mlir/src/compiler/mlir_ops.rs
@@ -33,6 +33,20 @@ impl<'ctx> Compiler<'ctx> {
         ))
     }
 
+    pub fn op_add_with_overflow<'a>(
+        &self,
+        block: &'a Block,
+        lhs: Value,
+        rhs: Value,
+    ) -> OperationRef<'a> {
+        block.append_operation(
+            operation::Builder::new("arith.addui_extended", Location::unknown(&self.context))
+                .add_operands(&[lhs, rhs])
+                .add_results(&[lhs.r#type(), self.bool_type()])
+                .build(),
+        )
+    }
+
     /// Only the MLIR op, doesn't do modulo.
     pub fn op_sub<'a>(&self, block: &'a Block, lhs: Value, rhs: Value) -> OperationRef<'a> {
         block.append_operation(arith::subi(
@@ -41,6 +55,23 @@ impl<'ctx> Compiler<'ctx> {
             lhs.r#type(),
             Location::unknown(&self.context),
         ))
+    }
+
+    pub fn op_llvm_sub_with_overflow<'a>(
+        &self,
+        block: &'a Block,
+        lhs: Value,
+        rhs: Value,
+    ) -> OperationRef<'a> {
+        block.append_operation(
+            operation::Builder::new(
+                "llvm.intr.usub.with.overflow",
+                Location::unknown(&self.context),
+            )
+            .add_operands(&[lhs, rhs])
+            .add_results(&[lhs.r#type(), self.bool_type()])
+            .build(),
+        )
     }
 
     /// Only the MLIR op.

--- a/sierra2mlir/src/libfuncs/lib_func_def.rs
+++ b/sierra2mlir/src/libfuncs/lib_func_def.rs
@@ -1,4 +1,7 @@
+use std::collections::BTreeMap;
+
 use itertools::Itertools;
+use melior_next::ir::Type;
 
 use crate::sierra_type::SierraType;
 
@@ -11,9 +14,46 @@ pub struct PositionalArg<'ctx> {
     pub(crate) ty: SierraType<'ctx>,
 }
 
+// The first step in implementating branching libfuncs is to select which branch to pick
+// For some functions, such as X_is_zero, an input suffices, since the last branch is the switch's default block
+// For others, a function must be called. E.g. for enum_match, a function needs to be called to get the enum's tag
+// The ability to select which return from the selector function is the value to use allows for optimisation where
+// selector and branch data can be calculated at the same time
+#[derive(Debug, Clone)]
+pub enum BranchSelector<'ctx> {
+    Arg(PositionalArg<'ctx>),
+    Call {
+        name: String,
+        args: Vec<PositionalArg<'ctx>>,
+        return_type: Type<'ctx>,
+        return_pos: usize,
+    },
+}
+
+// Each branch needs to take some subset of the libfunc's arguments and turn them into the data passed to that branch
+// There are 3 options:
+//  Some branches receive no data, so there is nothing to do. This is represented as with option 2 but with an empty list
+//  Some branches receive directly forwarded arguments of the libfuncs, such as with the X_is_zero functions
+//  Some branches receive data that has been transformed from the arguments of the libfuncs
+//    In a subset of these cases, the transformation occurs as part of the selector function,
+//    in which case SelectorResult can be used to indicate which results to use and their type
+#[derive(Debug, Clone)]
+pub enum BranchProcessing<'ctx> {
+    // The usize is for the index of the return value the arg is used for, allowing skipping of builtins
+    Args (Vec<(PositionalArg<'ctx>, usize)>),
+    Call { name: String, args: Vec<PositionalArg<'ctx>>, return_types: Vec<SierraType<'ctx>> },
+    SelectorResult(Vec<(PositionalArg<'ctx>, usize)>),
+}
+
+impl<'ctx> BranchProcessing<'ctx> {
+    pub fn none() -> Self {
+        Self::Args(vec![])
+    }
+}
+
 #[derive(Debug, Clone)]
 pub enum SierraLibFunc<'ctx> {
-    Branching { args: Vec<PositionalArg<'ctx>>, return_types: Vec<Vec<PositionalArg<'ctx>>> },
+    Branching { selector: BranchSelector<'ctx>, branch_processing: Vec<BranchProcessing<'ctx>> },
     Constant { ty: SierraType<'ctx>, value: String },
     Function { args: Vec<PositionalArg<'ctx>>, return_types: Vec<PositionalArg<'ctx>> },
     // Cases such as store_temp and dup that can be implemented purely at a dataflow level with no processing
@@ -48,16 +88,34 @@ impl<'ctx> SierraLibFunc<'ctx> {
             SierraLibFunc::Function { args, return_types: _ } => args.clone(),
             SierraLibFunc::Constant { ty: _, value: _ } => vec![],
             SierraLibFunc::InlineDataflow(args) => args.clone(),
-            SierraLibFunc::Branching { args, return_types: _ } => args.clone(),
-        }
-    }
+            SierraLibFunc::Branching { selector, branch_processing } => {
+                // We don't want to return duplicates, just one PositionalArg for each argument of the libfunc that we need
+                // As such, we're going to construct a map from the args used for the selector and the branch processing
+                let mut args_used = BTreeMap::new();
+                //
+                match selector {
+                    BranchSelector::Arg(arg) => {
+                        args_used.insert(arg.loc, arg.clone());
+                    }
+                    BranchSelector::Call { args, .. } => {
+                        args_used.extend(args.iter().map(|arg| (arg.loc, arg.clone())))
+                    }
+                }
 
-    pub fn get_return_types(&self) -> Vec<Vec<PositionalArg<'ctx>>> {
-        match self {
-            SierraLibFunc::Function { return_types, .. } => vec![return_types.clone()],
-            SierraLibFunc::Constant { .. } => vec![],
-            SierraLibFunc::InlineDataflow(_) => vec![],
-            SierraLibFunc::Branching { return_types, .. } => return_types.clone(),
+                for processing in branch_processing.iter() {
+                    match processing {
+                        BranchProcessing::Args(args) => {
+                            args_used.extend(args.iter().map(|(arg, _)| (arg.loc, arg.clone())));
+                        }
+                        BranchProcessing::Call { args, .. } => {
+                            args_used.extend(args.iter().map(|arg| (arg.loc, arg.clone())));
+                        },
+                        BranchProcessing::SelectorResult(_) => {}
+                    }
+                }
+
+                args_used.into_values().collect()
+            }
         }
     }
 
@@ -67,9 +125,7 @@ impl<'ctx> SierraLibFunc<'ctx> {
             SierraLibFunc::Function { args: _, return_types } => return_types.is_empty(),
             SierraLibFunc::Constant { ty: _, value: _ } => false,
             SierraLibFunc::InlineDataflow(returns) => returns.is_empty(),
-            SierraLibFunc::Branching { args: _, return_types } => {
-                return_types.len() == 1 && return_types[0].is_empty()
-            }
+            SierraLibFunc::Branching { .. } => false,
         }
     }
 }

--- a/sierra2mlir/src/statements/general_libfunc_implementations.rs
+++ b/sierra2mlir/src/statements/general_libfunc_implementations.rs
@@ -48,7 +48,7 @@ impl<'block, 'ctx> Compiler<'ctx> {
                 self.process_dataflow_libfunc(args_forwarded, invocation, variables);
                 Ok(())
             }
-            SierraLibFunc::Branching { args: _, return_types: _ } => {
+            SierraLibFunc::Branching { .. } => {
                 panic!(
                     "Branching SierraLibFunc should have been handled specifically: {:?}",
                     &invocation.libfunc_id.debug_name

--- a/sierra2mlir/src/statements/inline_jumps.rs
+++ b/sierra2mlir/src/statements/inline_jumps.rs
@@ -1,6 +1,5 @@
 use std::{
     collections::{BTreeMap, HashMap},
-    ops::{Deref, Shl},
 };
 
 use cairo_lang_sierra::program::{GenBranchTarget, Invocation};
@@ -8,12 +7,13 @@ use color_eyre::Result;
 use itertools::Itertools;
 use melior_next::{
     dialect::cf,
-    ir::{operation, Block, BlockRef, Location, Region, Value, ValueLike},
+    ir::{Block, Location, Region, Value, ValueLike},
 };
-use num_bigint::BigUint;
-use num_traits::FromPrimitive;
 
-use crate::compiler::mlir_ops::CmpOp;
+use crate::{
+    compiler::mlir_ops::CmpOp,
+    libfuncs::lib_func_def::{BranchProcessing, BranchSelector, SierraLibFunc},
+};
 use crate::{
     compiler::{Compiler, Storage},
     sierra_type::SierraType,
@@ -51,783 +51,255 @@ impl<'ctx> Compiler<'ctx> {
         Ok(())
     }
 
-    pub fn inline_int_is_zero(
+    pub fn inline_branching_libfunc(
         &'ctx self,
-        name: &str,
-        invocation: &Invocation,
-        block: &Block<'ctx>,
-        variables: &mut HashMap<u64, Variable>,
-        blocks: &BTreeMap<usize, BlockInfo<'ctx>>,
+        id: &str,
         statement_idx: usize,
+        region: &Region,
+        block: &Block,
+        blocks: &BTreeMap<usize, BlockInfo>,
+        invocation: &Invocation,
+        variables: &HashMap<u64, Variable>,
+        storage: &mut Storage<'ctx>,
     ) -> Result<()> {
-        let op_zero = match name {
-            "u8_is_zero" => self.op_u8_const(block, "0"),
-            "u16_is_zero" => self.op_u16_const(block, "0"),
-            "u32_is_zero" => self.op_u32_const(block, "0"),
-            "u64_is_zero" => self.op_u64_const(block, "0"),
-            "u128_is_zero" => self.op_u128_const(block, "0"),
-            "felt252_is_zero" => self.op_felt_const(block, "0"),
-            _ => panic!("Unexpected is_zero libfunc name {}", name),
+        println!("Processing {}", id);
+
+        let libfunc = storage.libfuncs.get(id).unwrap();
+
+        let (selector, branch_processing) =
+            if let SierraLibFunc::Branching { selector, branch_processing } = libfunc {
+                (selector, branch_processing)
+            } else {
+                panic!()
+            };
+
+        let selector_var = match selector {
+            BranchSelector::Arg(arg) => *variables.get(&invocation.args[arg.loc].id).unwrap(),
+            BranchSelector::Call { name, args, return_type, return_pos } => {
+                let resolved_args = args
+                    .iter()
+                    .map(|arg| variables.get(&invocation.args[arg.loc].id).unwrap().get_value())
+                    .collect_vec();
+                let selector_op =
+                    self.op_func_call(block, name, &resolved_args, &[*return_type])?;
+                Variable::Local { op: selector_op, result_idx: *return_pos }
+            }
         };
-        let zero = op_zero.result(0)?.into();
 
-        let input = variables
-            .get(&invocation.args[0].id)
-            .expect("Variable should be registered before use")
-            .get_value();
-        let eq_op = self.op_cmp(block, CmpOp::Equal, input, zero);
-        let eq = eq_op.result(0)?;
+        let processing_blocks = branch_processing.iter().enumerate().map(|(branch_idx, processing)| {
+            let branch_info = &invocation.branches[branch_idx];
+            let block = self.new_block(&[]);
 
-        // X_is_zero forwards its argument to the non-zero branch
-        // Since no processing is done, we can simply assign to the variable here
-        variables.insert(
-            invocation.branches[1].results[0].id,
-            *variables.get(&invocation.args[0].id).unwrap(),
-        );
-        let target_blocks = invocation
-            .branches
-            .iter()
-            .map(|branch| match branch.target {
-                GenBranchTarget::Fallthrough => statement_idx + 1,
-                GenBranchTarget::Statement(idx) => idx.0,
-            })
-            .map(|idx| {
-                let target_block_info = blocks.get(&idx).unwrap();
-                let operand_values = target_block_info
-                    .variables_at_start
-                    .keys()
-                    .map(|id| variables.get(id).unwrap().get_value())
-                    .collect_vec();
-                (&target_block_info.block, operand_values)
-            })
-            .collect_vec();
-
-        let (zero_block, zero_vars) = &target_blocks[0];
-        let (nonzero_block, nonzero_vars) = &target_blocks[1];
-
-        self.op_cond_br(block, eq.into(), zero_block, nonzero_block, zero_vars, nonzero_vars);
-
-        Ok(())
-    }
-
-    // eq, le, lt
-    pub fn inline_int_cmpop(
-        &'ctx self,
-        id: &str,
-        invocation: &Invocation,
-        block: &Block<'ctx>,
-        variables: &HashMap<u64, Variable>,
-        blocks: &BTreeMap<usize, BlockInfo<'ctx>>,
-        statement_idx: usize,
-        storage: &Storage,
-        cmpop: CmpOp,
-    ) -> Result<()> {
-        let libfunc = storage.libfuncs.get(id).unwrap();
-        let pos_arg_1 = &libfunc.get_args()[0];
-        let pos_arg_2 = &libfunc.get_args()[1];
-
-        let arg1 = variables
-            .get(&invocation.args[pos_arg_1.loc].id)
-            .expect("Variable should be registered before use")
-            .get_value();
-
-        let arg2 = variables
-            .get(&invocation.args[pos_arg_2.loc].id)
-            .expect("Variable should be registered before use")
-            .get_value();
-
-        let eq_op = self.op_cmp(block, cmpop, arg1, arg2);
-        let eq = eq_op.result(0)?;
-
-        let target_blocks = invocation
-            .branches
-            .iter()
-            .map(|branch| match branch.target {
-                GenBranchTarget::Fallthrough => statement_idx + 1,
-                GenBranchTarget::Statement(idx) => idx.0,
-            })
-            .map(|idx| {
-                let target_block_info = blocks.get(&idx).unwrap();
-                let operand_values = target_block_info
-                    .variables_at_start
-                    .keys()
-                    .map(|id| variables.get(id).unwrap().get_value())
-                    .collect_vec();
-                (&target_block_info.block, operand_values)
-            })
-            .collect_vec();
-
-        let (true_block, true_vars) = &target_blocks[1];
-        let (false_block, false_vars) = &target_blocks[0];
-
-        self.op_cond_br(block, eq.into(), true_block, false_block, true_vars, false_vars);
-
-        Ok(())
-    }
-
-    // https://github.com/starkware-libs/cairo/blob/main/crates/cairo-lang-sierra/src/extensions/modules/uint.rs#L339
-    pub fn inline_int_overflowing_op(
-        &'ctx self,
-        id: &str,
-        invocation: &Invocation,
-        block: &Block<'ctx>,
-        variables: &HashMap<u64, Variable>,
-        blocks: &BTreeMap<usize, BlockInfo<'ctx>>,
-        statement_idx: usize,
-        storage: &Storage,
-        // true = add, false = sub
-        is_add: bool,
-    ) -> Result<()> {
-        let libfunc = storage.libfuncs.get(id).unwrap();
-        let pos_arg_1 = &libfunc.get_args()[0];
-        let pos_arg_2 = &libfunc.get_args()[1];
-
-        let arg_type = pos_arg_1.ty.clone();
-
-        let arg1 = variables
-            .get(&invocation.args[pos_arg_1.loc].id)
-            .expect("Variable should be registered before use")
-            .get_value();
-
-        let arg2 = variables
-            .get(&invocation.args[pos_arg_2.loc].id)
-            .expect("Variable should be registered before use")
-            .get_value();
-
-        let overflow_result_op = block.append_operation(
-            operation::Builder::new(
-                if is_add {
-                    "llvm.intr.uadd.with.overflow"
-                } else {
-                    "llvm.intr.usub.with.overflow"
+            // A map of the variables produced by this libfunc
+            let branch_vars = match processing {
+                BranchProcessing::Args(args) => {
+                    args.iter().map(|(arg, res_idx)| (branch_info.results[*res_idx].id, *variables.get(&invocation.args[arg.loc].id).unwrap())).collect::<BTreeMap<_, _>>()
                 },
-                Location::unknown(&self.context),
-            )
-            .add_operands(&[arg1, arg2])
-            .add_results(&[self.llvm_struct_type(&[arg1.r#type(), self.bool_type()], false)])
-            .build(),
-        );
-
-        // {iN, i1}
-        let overflow_result = overflow_result_op.result(0)?.into();
-        let result_op =
-            self.op_llvm_extractvalue(block, 0, overflow_result, arg_type.get_type())?;
-        let overflow_op = self.op_llvm_extractvalue(block, 1, overflow_result, self.bool_type())?;
-
-        let result = result_op.result(0)?.into();
-
-        let overflow = overflow_op.result(0)?;
-
-        let target_blocks = invocation
-            .branches
-            .iter()
-            .map(|branch| match branch.target {
-                GenBranchTarget::Fallthrough => statement_idx + 1,
-                GenBranchTarget::Statement(idx) => idx.0,
-            })
-            .map(|idx| {
-                let target_block_info = blocks.get(&idx).unwrap();
-                let operand_values = target_block_info
-                    .variables_at_start
-                    .keys()
-                    .map(|id| {
-                        if *id == invocation.branches[0].results[1].id
-                            || *id == invocation.branches[1].results[1].id
-                        {
-                            result
-                        } else {
-                            variables.get(id).unwrap().get_value()
-                        }
-                    })
-                    .collect_vec();
-                (&target_block_info.block, operand_values)
-            })
-            .collect_vec();
-
-        let (true_block, true_vars) = &target_blocks[1];
-        let (false_block, false_vars) = &target_blocks[0];
-
-        self.op_cond_br(block, overflow.into(), true_block, false_block, true_vars, false_vars);
-
-        Ok(())
-    }
-
-    pub fn inline_try_from_felt252(
-        &'ctx self,
-        id: &str,
-        invocation: &Invocation,
-        region: &Region,
-        block: &Block<'ctx>,
-        variables: &HashMap<u64, Variable>,
-        blocks: &BTreeMap<usize, BlockInfo<'ctx>>,
-        statement_idx: usize,
-        storage: &Storage,
-    ) -> Result<()> {
-        let libfunc = storage.libfuncs.get(id).expect("should find libfunc");
-        let pos_arg_1 = &libfunc.get_args()[0]; // always felt type
-        let ret_pos_type = &libfunc.get_return_types()[0][0];
-        let ret_type = &ret_pos_type.ty;
-
-        let arg_type = &pos_arg_1.ty;
-        let arg = variables
-            .get(&invocation.args[pos_arg_1.loc].id)
-            .expect("Variable should be registered before use")
-            .get_value();
-
-        let max_value = BigUint::from_i32(1).unwrap().shl(ret_type.get_width());
-        let max_val = self.op_const(block, &max_value.to_string(), arg_type.get_type());
-
-        let cmp_op = self.op_cmp(block, CmpOp::UnsignedLessThan, arg, max_val.result(0)?.into());
-        let cmp = cmp_op.result(0)?.into();
-
-        let trunc_block = region.append_block(Block::new(&[]));
-
-        // truncate block
-        let trunc_op = self.op_trunc(&trunc_block, arg, ret_type.get_type());
-        let trunc_res = trunc_op.result(0)?.into();
-
-        let target_blocks = invocation
-            .branches
-            .iter()
-            .map(|branch| match branch.target {
-                GenBranchTarget::Fallthrough => statement_idx + 1,
-                GenBranchTarget::Statement(idx) => idx.0,
-            })
-            .map(|idx| {
-                let target_block_info = blocks.get(&idx).unwrap();
-                let operand_values = target_block_info
-                    .variables_at_start
-                    .keys()
-                    .map(|id| {
-                        if *id == invocation.branches[0].results[1].id {
-                            trunc_res
-                        } else {
-                            variables.get(id).unwrap().get_value()
-                        }
-                    })
-                    .collect_vec();
-                (&target_block_info.block, operand_values)
-            })
-            .collect_vec();
-
-        let (true_block, true_vars) = &target_blocks[0];
-        let (false_block, false_vars) = &target_blocks[1];
-
-        self.op_cond_br(block, cmp, &trunc_block, false_block, &[], false_vars);
-        self.op_br(&trunc_block, true_block, true_vars);
-
-        Ok(())
-    }
-
-    pub fn inline_enum_match(
-        &'ctx self,
-        id: &str,
-        statement_idx: usize,
-        region: &Region,
-        block: &Block,
-        blocks: &BTreeMap<usize, BlockInfo>,
-        invocation: &Invocation,
-        variables: &HashMap<u64, Variable>,
-        storage: &mut Storage<'ctx>,
-    ) -> Result<()> {
-        let args = storage.libfuncs.get(id).unwrap().get_args();
-
-        let enum_type = &args[0].ty;
-        let enum_name = id.strip_prefix("enum_match<").unwrap().strip_suffix('>').unwrap();
-
-        let variant_count = match enum_type {
-            SierraType::Enum { variants_types, .. } => variants_types.len(),
-            _ => panic!("Argument of enum match should be an enum"),
-        };
-
-        // Get the argument- the enum to case split upon
-        let enum_value = variables.get(&invocation.args[0].id).unwrap().get_value();
-
-        // get the tag
-        let tag_op = self.call_enum_get_tag(block, enum_value, enum_type, storage)?;
-        let tag = tag_op.result(0)?.into();
-
-        // Blocks for the switch statement to jump to. Each extract's the appropriate value and forwards it on
-        let variant_blocks: Vec<BlockRef> = (0..variant_count)
-            .map(|variant_index| {
-                // Intermediary block in which to extract the correct data from the enum
-                let variant_block = region.append_block(Block::new(&[]));
-                // Target block to jump to as the result of the match
-                let target_block_info = blocks
-                    .get(&match invocation.branches[variant_index].target {
-                        GenBranchTarget::Fallthrough => statement_idx + 1,
-                        GenBranchTarget::Statement(idx) => idx.0,
-                    })
-                    .unwrap();
-
-                let mut args_to_target_block = vec![];
-                for var_idx in target_block_info.variables_at_start.keys() {
-                    if *var_idx == invocation.branches[variant_index].results[0].id {
-                        let get_data_op = self.call_enum_get_data_as_variant_type(
-                            &variant_block,
-                            enum_name,
-                            enum_value,
-                            enum_type,
-                            variant_index,
-                            storage,
-                        )?;
-                        args_to_target_block
-                            .push(Variable::Local { op: get_data_op, result_idx: 0 });
+                BranchProcessing::Call { name, args, return_types } => {
+                    let resolved_args = args.iter().map(|arg| variables.get(&invocation.args[arg.loc].id).unwrap().get_value()).collect_vec();
+                    let resolved_ret_types = return_types.iter().map(SierraType::get_type).collect_vec();
+                    let op = self.op_func_call(&block, name, &resolved_args, &resolved_ret_types)?;
+                    (0..branch_info.results.len()).map(|idx| (branch_info.results[idx].id, Variable::Local { op: op, result_idx: idx })).collect::<BTreeMap<_, _>>()
+                },
+                BranchProcessing::SelectorResult(results) => {
+                    if let Variable::Local { op, .. } = selector_var {
+                        results.iter().map(|(arg, res_idx)| (branch_info.results[*res_idx].id, Variable::Local { op, result_idx: arg.loc })).collect::<BTreeMap<_, _>>()
                     } else {
-                        args_to_target_block.push(*variables.get(var_idx).unwrap());
+                        panic!("BranchProcessing::SelectorResult can only be used with BranchSelector::Call")
                     }
-                }
-                let args_to_target_block =
-                    args_to_target_block.iter().map(Variable::get_value).collect_vec();
+                },
+            };
 
-                self.op_br(&variant_block, &target_block_info.block, &args_to_target_block);
-
-                Ok(variant_block)
-            })
-            .collect::<Result<Vec<BlockRef>>>()?;
-
-        let case_values = (0..variant_count).map(|x| x.to_string()).collect_vec();
-        // The default block is unreachable
-        // NOTE To truly guarantee this, we'll need guards on external inputs once we take them
-        let default_block = region.append_block(Block::new(&[]));
-        self.op_unreachable(&default_block);
-
-        let variant_blocks_with_ops =
-            variant_blocks.iter().map(|x| (x.deref(), [].as_slice())).collect_vec();
-        block.append_operation(cf::switch(
-            &self.context,
-            &case_values,
-            tag,
-            (&default_block, &[]),
-            variant_blocks_with_ops.as_slice(),
-            Location::unknown(&self.context),
-        ));
-
-        Ok(())
-    }
-
-    #[allow(clippy::too_many_arguments)]
-    pub fn inline_array_get(
-        &'ctx self,
-        id: &str,
-        statement_idx: usize,
-        region: &Region,
-        block: &Block,
-        blocks: &BTreeMap<usize, BlockInfo>,
-        invocation: &Invocation,
-        variables: &HashMap<u64, Variable>,
-        storage: &mut Storage<'ctx>,
-    ) -> Result<()> {
-        let libfunc = storage.libfuncs.get(id).unwrap();
-        let array_arg = &libfunc.get_args()[0];
-        let index_arg = &libfunc.get_args()[1];
-
-        // fallthrough if ok
-        // jump if panic
-
-        // 0 = ok block, 1 = panic block
-        let target_blocks = invocation
-            .branches
-            .iter()
-            .map(|branch| match branch.target {
+            let target_block_info = blocks.get(&match branch_info.target {
                 GenBranchTarget::Fallthrough => statement_idx + 1,
                 GenBranchTarget::Statement(idx) => idx.0,
-            })
-            .map(|idx| {
-                let target_block_info = blocks.get(&idx).unwrap();
-                target_block_info
-            })
-            .collect_vec();
+            }).unwrap();
 
-        let target_block_info = target_blocks[0];
-        let panic_block_info = target_blocks[1];
+            let args_to_target_block = target_block_info.variables_at_start.keys().map(|id| {
+                branch_vars.get(id).unwrap_or_else(|| variables.get(id).unwrap()).get_value()
+            }).collect_vec();
 
-        // Our implementation of array_get takes two values: the array and the index (sierra's array_get also takes RangeCheck)
+            self.op_br(&block, &target_block_info.block, &args_to_target_block);
 
-        let array_value = variables
-            .get(&invocation.args[array_arg.loc].id)
-            .expect("variable array should exist")
-            .get_value();
-        let index_value = variables
-            .get(&invocation.args[index_arg.loc].id)
-            .expect("variable index should exist")
-            .get_value();
+            Ok(block)
+        }).collect::<Result<Vec<_>>>()?;
 
-        // get the current length
-        let length_op = self.call_array_len_impl(block, array_value, &array_arg.ty, storage)?;
-        let length: Value = length_op.result(0)?.into();
-
-        // check if index is out of bounds
-        let in_bounds_op = self.op_cmp(block, CmpOp::UnsignedLessThan, index_value, length);
-        let in_bounds = in_bounds_op.result(0)?.into();
-
-        // Create a block in which to get the element once we know its index is valid
-        let in_bounds_block = region.append_block(Block::new(&[]));
-
-        // collect args to the panic block
-        let args_to_panic_block = panic_block_info
-            .variables_at_start
-            .keys()
-            .map(|var_idx| variables.get(var_idx).unwrap().get_value())
-            .collect_vec();
-
-        // Jump to the in_bounds_block if the index is valid, or to the panic_block if not
-        self.op_cond_br(
-            block,
-            in_bounds,
-            &in_bounds_block,
-            &panic_block_info.block,
-            &[],
-            &args_to_panic_block,
-        );
-
-        // get the value at index
-
-        let element_op = self.call_array_get_unchecked(
-            &in_bounds_block,
-            array_value,
-            index_value,
-            &array_arg.ty,
-            storage,
-        )?;
-
-        let target_value_var_id = invocation.branches[0].results[1].id;
-
-        // get the args to the target block (fallthrough here)
-        let args_to_target_block = target_block_info
-            .variables_at_start
-            .keys()
-            .map(|var_idx| {
-                if *var_idx == target_value_var_id {
-                    Variable::Local { op: element_op, result_idx: 0 }
-                } else {
-                    *variables.get(var_idx).unwrap()
-                }
-            })
-            .collect_vec();
-        let args_to_target_block =
-            args_to_target_block.iter().map(Variable::get_value).collect_vec();
-
-        self.op_br(&in_bounds_block, &target_block_info.block, &args_to_target_block);
-
-        Ok(())
-    }
-
-    pub fn inline_array_pop_front(
-        &'ctx self,
-        id: &str,
-        statement_idx: usize,
-        region: &Region,
-        block: &Block,
-        blocks: &BTreeMap<usize, BlockInfo>,
-        invocation: &Invocation,
-        variables: &HashMap<u64, Variable>,
-        storage: &mut Storage<'ctx>,
-    ) -> Result<()> {
-        let libfunc = storage.libfuncs.get(id).unwrap();
-        let array_arg = &libfunc.get_args()[0];
-
-        // fallthrough if there is a element to pop
-        // jump otherwise
-
-        let target_blocks = invocation
-            .branches
-            .iter()
-            .map(|branch| match branch.target {
-                GenBranchTarget::Fallthrough => statement_idx + 1,
-                GenBranchTarget::Statement(idx) => idx.0,
-            })
-            .map(|idx| {
-                let target_block_info = blocks.get(&idx).unwrap();
-                target_block_info
-            })
-            .collect_vec();
-
-        let some_block_info = target_blocks[0];
-        let none_block_info = target_blocks[1];
-
-        let (array_type, element_type) = match &array_arg.ty {
-            SierraType::Array { ty, len_type: _, element_type } => (*ty, element_type),
-            _ => panic!("argument should be array type"),
-        };
-
-        let array_var =
-            variables.get(&invocation.args[array_arg.loc].id).expect("variable array should exist");
-
-        let array_value = array_var.get_value();
-
-        let const_1_op = self.op_u32_const(block, "1");
-        let const_1 = const_1_op.result(0)?.into();
-        let const_0_op = self.op_u32_const(block, "0");
-        let const_0 = const_0_op.result(0)?.into();
-
-        // get the current length
-        let length_op = self.call_array_len_impl(block, array_value, &array_arg.ty, storage)?;
-        let length: Value = length_op.result(0)?.into();
-
-        // check if there is something to pop
-        let cmp_op = self.op_cmp(block, CmpOp::UnsignedGreaterThanEqual, length, const_1);
-        let cmp = cmp_op.result(0)?.into();
-
-        let block_pop_idx = region.append_block(Block::new(&[]));
-
-        // collect args to the none block
-        let args_to_none_block = none_block_info
-            .variables_at_start
-            .keys()
-            .map(|var_idx| {
-                if *var_idx == invocation.branches[1].results[0].id {
-                    *array_var
-                } else {
-                    *variables.get(var_idx).unwrap()
-                }
-            })
-            .collect_vec();
-
-        let args_to_none_block = args_to_none_block.iter().map(Variable::get_value).collect_vec();
-
-        self.op_cond_br(
-            block,
-            cmp,
-            &block_pop_idx,
-            &none_block_info.block,
-            &[],
-            &args_to_none_block,
-        );
-
-        // get the element to return
-        let first_element_op = self.call_array_get_unchecked(
-            &block_pop_idx,
-            array_value,
-            const_0,
-            &array_arg.ty,
-            storage,
-        )?;
-
-        // decrement the length
-        let new_length_op = self.op_sub(&block_pop_idx, length, const_1);
-        let new_length = new_length_op.result(0)?.into();
-
-        // get the current data ptr, and the pointer to the second element
-        let data_ptr_op =
-            self.op_llvm_extractvalue(&block_pop_idx, 2, array_value, self.llvm_ptr_type())?;
-        let data_ptr: Value = data_ptr_op.result(0)?.into();
-        let src_ptr_op = self.op_llvm_gep_dynamic(
-            &block_pop_idx,
-            &[const_1],
-            data_ptr,
-            element_type.get_type(),
-        )?;
-        let src_ptr = src_ptr_op.result(0)?.into();
-
-        // its safe if new_length is 0
-        let new_length_zext_op = self.op_zext(&block_pop_idx, new_length, self.u64_type());
-        let new_length_zext = new_length_zext_op.result(0)?.into();
-
-        let element_size_bytes = (element_type.get_width() + 7) / 8;
-        let const_element_size_bytes =
-            self.op_const(&block_pop_idx, &element_size_bytes.to_string(), self.u64_type());
-
-        let new_length_bytes_op = self.op_mul(
-            &block_pop_idx,
-            new_length_zext,
-            const_element_size_bytes.result(0)?.into(),
-        );
-        let new_length_bytes = new_length_bytes_op.result(0)?.into();
-
-        let dst_ptr_op =
-            self.call_memmove(&block_pop_idx, data_ptr, src_ptr, new_length_bytes, storage)?;
-        let dst_ptr: Value = dst_ptr_op.result(0)?.into();
-
-        // insert new length
-        let insert_op =
-            self.op_llvm_insertvalue(&block_pop_idx, 0, array_value, new_length, array_type)?;
-        let array_value: Value = insert_op.result(0)?.into();
-
-        // insert new ptr
-        let insert_array_op =
-            self.op_llvm_insertvalue(&block_pop_idx, 2, array_value, dst_ptr, array_type)?;
-
-        // get the args to the target block (fallthrough here)
-        let args_to_target_block = some_block_info
-            .variables_at_start
-            .keys()
-            .map(|var_idx| {
-                let array_value_id = invocation.branches[0].results[0].id;
-                let popped_value_id = invocation.branches[0].results[1].id;
-                match *var_idx {
-                    // popped value
-                    var_idx if var_idx == popped_value_id => {
-                        Variable::Local { op: first_element_op, result_idx: 0 }
-                    }
-                    // updated array
-                    var_idx if var_idx == array_value_id => {
-                        Variable::Local { op: insert_array_op, result_idx: 0 }
-                    }
-                    var_idx => *variables.get(&var_idx).unwrap(),
-                }
-            })
-            .collect_vec();
-        let args_to_target_block =
-            args_to_target_block.iter().map(Variable::get_value).collect_vec();
-
-        self.op_br(&block_pop_idx, &some_block_info.block, &args_to_target_block);
-
-        Ok(())
-    }
-
-    pub fn inline_downcast(
-        &'ctx self,
-        id: &str,
-        invocation: &Invocation,
-        region: &Region,
-        block: &Block<'ctx>,
-        variables: &HashMap<u64, Variable>,
-        blocks: &BTreeMap<usize, BlockInfo<'ctx>>,
-        statement_idx: usize,
-        storage: &Storage,
-    ) -> Result<()> {
-        let libfunc = storage.libfuncs.get(id).expect("should find libfunc");
-        let pos_arg_1 = &libfunc.get_args()[0];
-        let ret_pos_type = &libfunc.get_return_types()[0][0];
-        let ret_type = &ret_pos_type.ty;
-
-        let arg_type = &pos_arg_1.ty;
-        let arg = variables
-            .get(&invocation.args[pos_arg_1.loc].id)
-            .expect("Variable should be registered before use")
-            .get_value();
-
-        let cmp_op = if arg_type.get_width() == ret_type.get_width() {
-            self.op_const(block, "1", self.bool_type())
-        } else {
-            let max_val = self.op_const(
-                block,
-                &(BigUint::from_i32(1).unwrap().shl(ret_type.get_width())).to_string(),
-                arg_type.get_type(),
+        if processing_blocks.len() == 2 {
+            let zero_op = self.op_const(&block, "0", self.bool_type());
+            let zero = zero_op.result(0)?.into();
+            let selector_eq_zero_op = self.op_cmp(&block, CmpOp::Equal, selector_var.get_value(), zero);
+            let selector_eq_zero = selector_eq_zero_op.result(0)?.into();
+            self.op_cond_br(
+                &block,
+                selector_eq_zero,
+                &processing_blocks[0],
+                &processing_blocks[1],
+                &[],
+                &[],
             );
+        } else {
+            let case_values = (0..processing_blocks.len() - 1).map(|x| x.to_string()).collect_vec();
+            let (default_block, case_blocks) = processing_blocks.split_last().unwrap();
 
-            let cmp_op =
-                self.op_cmp(block, CmpOp::UnsignedLessThan, arg, max_val.result(0)?.into());
-            cmp_op
-        };
-        let cmp = cmp_op.result(0)?.into();
+            block.append_operation(cf::switch(
+                &self.context,
+                &case_values,
+                selector_var.get_value(),
+                (&default_block, &[]),
+                &case_blocks.iter().map(|b| (b, &[] as &[Value])).collect_vec(),
+                Location::unknown(&self.context),
+            ));
+        }
 
-        let trunc_block = region.append_block(Block::new(&[]));
-
-        // truncate block
-        let trunc_op = self.op_trunc(&trunc_block, arg, ret_type.get_type());
-        let trunc_res = trunc_op.result(0)?.into();
-
-        let target_blocks = invocation
-            .branches
-            .iter()
-            .map(|branch| match branch.target {
-                GenBranchTarget::Fallthrough => statement_idx + 1,
-                GenBranchTarget::Statement(idx) => idx.0,
-            })
-            .map(|idx| {
-                let target_block_info = blocks.get(&idx).unwrap();
-                let operand_values = target_block_info
-                    .variables_at_start
-                    .keys()
-                    .map(|id| {
-                        if *id == invocation.branches[0].results[1].id {
-                            trunc_res
-                        } else {
-                            variables.get(id).unwrap().get_value()
-                        }
-                    })
-                    .collect_vec();
-                (&target_block_info.block, operand_values)
-            })
-            .collect_vec();
-
-        let (true_block, true_vars) = &target_blocks[0];
-        let (false_block, false_vars) = &target_blocks[1];
-
-        self.op_cond_br(block, cmp, &trunc_block, false_block, &[], false_vars);
-        self.op_br(&trunc_block, true_block, true_vars);
+        for b in processing_blocks {
+            region.append_block(b);
+        }
 
         Ok(())
+
+        // let target_function_args = args
+        //     .iter()
+        //     .map(|arg| variables.get(&invocation.args[arg.loc].id).unwrap().get_value())
+        //     .collect_vec();
+
+        // let selector_call = match selector {
+        //     BranchSelector::Call(name) => {
+        //         Some(self.op_func_call(block, name, &target_function_args, &[index_type])?)
+        //     }
+        //     BranchSelector::Arg(_) => None,
+        // };
+
+        // let selector_value = match selector {
+        //     BranchSelector::Call(_) => selector_call.as_ref().unwrap().result(0)?.into(),
+        //     BranchSelector::Arg(arg) => {
+        //         variables.get(&invocation.args[arg.loc].id).unwrap().get_value()
+        //     }
+        // };
+
+        // let branch_blocks = branch_functions
+        //     .iter()
+        //     .enumerate()
+        //     .map(|(idx, branch_function)| {
+        //         let branch_info = &invocation.branches[idx];
+        //         let block = self.new_block(&[]);
+
+        //         let branch_vars: HashMap<u64, Variable> =
+        //             if let Some(BranchFunction { name, args, return_types }) = branch_function {
+        //                 let branch_function_args = args
+        //                     .iter()
+        //                     .map(|arg| {
+        //                         variables.get(&invocation.args[arg.loc].id).unwrap().get_value()
+        //                     })
+        //                     .collect_vec();
+        //                 let branch_function_ret_types =
+        //                     return_types.iter().map(|ret_ty| ret_ty.ty.get_type()).collect_vec();
+        //                 let branch_data_op = self.op_func_call(
+        //                     &block,
+        //                     name,
+        //                     &branch_function_args,
+        //                     &branch_function_ret_types,
+        //                 )?;
+        //                 return_types
+        //                     .iter()
+        //                     .enumerate()
+        //                     .map(|(result_idx, ret_type)| {
+        //                         let id = branch_info.results[ret_type.loc].id;
+        //                         (id, Variable::Local { op: branch_data_op, result_idx })
+        //                     })
+        //                     .collect()
+        //             } else {
+        //                 HashMap::new()
+        //             };
+
+        //         let target_block_info = blocks
+        //             .get(&match branch_info.target {
+        //                 GenBranchTarget::Fallthrough => statement_idx + 1,
+        //                 GenBranchTarget::Statement(idx) => idx.0,
+        //             })
+        //             .unwrap();
+
+        //         let args_to_target_block = target_block_info
+        //             .variables_at_start
+        //             .keys()
+        //             .map(|id| {
+        //                 branch_vars
+        //                     .get(id)
+        //                     .unwrap_or_else(|| variables.get(id).unwrap())
+        //                     .get_value()
+        //             })
+        //             .collect_vec();
+
+        //         self.op_br(&block, &target_block_info.block, &args_to_target_block);
+
+        //         Ok(block)
+        //     })
+        //     .collect::<Result<Vec<_>>>()?;
+
+        // let case_values = (0..branch_blocks.len() - 1).map(|x| x.to_string()).collect_vec();
+        // let (default_block, case_blocks) = branch_blocks.split_last().unwrap();
+
+        // block.append_operation(cf::switch(
+        //     &self.context,
+        //     &case_values,
+        //     selector_value,
+        //     (&default_block, &[]),
+        //     &case_blocks.iter().map(|b| (b, &[] as &[Value])).collect_vec(),
+        //     Location::unknown(&self.context),
+        // ));
+
+        // for b in branch_blocks {
+        //     region.append_block(b);
+        // }
+
+        // Ok(())
     }
 
-    pub fn inline_match_nullable(
-        &'ctx self,
-        id: &str,
-        statement_idx: usize,
-        block: &Block,
-        blocks: &BTreeMap<usize, BlockInfo>,
-        invocation: &Invocation,
-        variables: &HashMap<u64, Variable>,
-        storage: &mut Storage<'ctx>,
-    ) -> Result<()> {
-        let libfunc = storage.libfuncs.get(id).unwrap();
-        let nullable_arg = &libfunc.get_args()[0];
+    // fn inline_branching_libfunc_branches(
+    //     &'ctx self,
+    //     id: &str,
+    //     statement_idx: usize,
+    //     region: &Region,
+    //     block: &Block,
+    //     blocks: &BTreeMap<usize, BlockInfo>,
+    //     invocation: &Invocation,
+    //     variables: &HashMap<u64, Variable>,
+    //     selector: Value,
+    //     storage: &mut Storage<'ctx>,
+    // ) -> Result<()> {
+    //     let libfunc = storage.libfuncs.get(id).unwrap();
 
-        // fallthrough if null
-        // jump otherwise
+    //     let branch_processing = if let SierraLibFunc::Branching { branch_processing, .. } = libfunc
+    //     {
+    //         branch_processing
+    //     } else {
+    //         panic!()
+    //     };
 
-        let target_blocks = invocation
-            .branches
-            .iter()
-            .map(|branch| match &branch.target {
-                GenBranchTarget::Fallthrough => statement_idx + 1,
-                GenBranchTarget::Statement(idx) => idx.0,
-            })
-            .map(|idx| {
-                let target_block_info = blocks.get(&idx).unwrap();
-                target_block_info
-            })
-            .collect_vec();
+    //     let mut processing_blocks = vec![];
 
-        let fallthrough_block = target_blocks[0];
-        let notnull_block = target_blocks[1];
+    //     for (branch_idx, processing) in branch_processing.iter().enumerate() {
+    //         let invocation_branch = &invocation.branches[branch_idx];
+    //         let generated_vars = match processing {
+    //             BranchProcessing::Args(args) => {
+    //                 args.iter().zip_eq(invocation_branch.results.iter()).map(|(arg, res)| {
+    //                     (res.id, variables.get(&invocation.args[arg.loc].id).unwrap().get_value())
+    //                 }).collect_vec()
+    //             }
+    //             BranchProcessing::Call { name, args, return_types } => {
+    //                 let block = self.new_block(&[]);
+    //                 let resolved_args = args.iter().map(|arg| variables.get(&invocation.args[arg.loc].id).unwrap().get_value()).collect_vec();
+    //                 let resolved_ret_types = return_types.iter().map(SierraType::get_type).collect_vec();
+    //                 let call_op = self.op_func_call(&block, name, &resolved_args, &resolved_ret_types)?;
+    //                 invocation_branch.results.iter().enumerate().map(|(i, res)| {
+    //                     (res.id, call_op.result(i).unwrap().into())
+    //                 }).collect_vec()
+    //             }
+    //             BranchProcessing::SelectorResult(results) => {
+    //                 todo!()
+    //             }
+    //         };
+    //     }
 
-        let nullable_value_type = nullable_arg.ty.get_field_types().unwrap()[0];
-
-        let nullable_value =
-            variables.get(&invocation.args[nullable_arg.loc].id).expect("variable should exist");
-
-        let is_null_op =
-            self.op_llvm_extractvalue(block, 1, nullable_value.get_value(), self.bool_type())?;
-        let is_null = is_null_op.result(0)?.into();
-
-        // collect args to the none block
-        let args_to_fallthrough = fallthrough_block
-            .variables_at_start
-            .keys()
-            .map(|var_idx| *variables.get(var_idx).unwrap())
-            .collect_vec();
-
-        let get_value_op =
-            self.op_llvm_extractvalue(block, 0, nullable_value.get_value(), nullable_value_type)?;
-
-        // collect args to the none block
-        let args_to_notnull = notnull_block
-            .variables_at_start
-            .keys()
-            .map(|var_idx| {
-                if *var_idx == invocation.branches[1].results[0].id {
-                    Variable::Local { op: get_value_op, result_idx: 0 }
-                } else {
-                    *variables.get(var_idx).unwrap()
-                }
-            })
-            .collect_vec();
-
-        let args_to_fallthrough = args_to_fallthrough.iter().map(Variable::get_value).collect_vec();
-        let args_to_notnull = args_to_notnull.iter().map(Variable::get_value).collect_vec();
-
-        self.op_cond_br(
-            block,
-            is_null,
-            &notnull_block.block,
-            &fallthrough_block.block,
-            &args_to_notnull,
-            &args_to_fallthrough,
-        );
-
-        Ok(())
-    }
+    //     Ok(())
+    // }
 }


### PR DESCRIPTION
# TITLE

## Description

All the custom implementations of the branching libfuncs were following a similar pattern of selector to decide which block to go to, then process to produce the results for that block. This PR standardises this in a way that is hopefully more concise and less error prone, whilst still lowering to the same compiled code

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
