### PR TITLE
don't rely on lli for tests, use file descriptor, improving stability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@nightly
         with:
           components: rustfmt
       - run: cargo fmt --all -- --check
@@ -89,7 +89,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Setup rust env
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@nightly
       - name: Retreive cached dependecies
         uses: Swatinem/rust-cache@v2
       - name: Install cargo-llvm-cov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       MLIR_SYS_160_PREFIX: /usr/lib/llvm-16/
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@nightly
         with:
           components: clippy
       - uses: Swatinem/rust-cache@v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,8 @@ members = [
     "sierra2mlir-utils",
     "cli"
 ]
+
+[profile.ci-coverage]
+inherits = "dev"
+opt-level = 3
+debug = true

--- a/Makefile
+++ b/Makefile
@@ -45,17 +45,17 @@ COMPARISON_TEST_TARGETS := $(patsubst %.cairo,%.sierra,$(COMPARISON_TEST_SOURCES
 %.ll: %.mlir
 	$(LLVM_PREFIX)/bin/mlir-translate --mlir-to-llvmir -o $@ $<
 
-build: $(BENCH_TARGETS)
+build:
 	cargo build --release
 
-check: $(BENCH_TARGETS)
+check:
 	cargo fmt --all -- --check
 	cargo clippy --all-targets -- -D warnings
 
-test: $(BENCH_TARGETS)
+test:
 	cargo test --all-targets
 
-coverage: $(BENCH_TARGETS)
+coverage:
 	cargo llvm-cov --profile "ci-coverage" --all-features --workspace --lcov --output-path lcov.info
 
 book:

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ test: $(BENCH_TARGETS)
 	cargo test --all-targets
 
 coverage: $(BENCH_TARGETS)
-	cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
+	cargo llvm-cov --profile "ci-coverage" --all-features --workspace --lcov --output-path lcov.info
 
 book:
 	mdbook serve docs

--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,7 @@ clean-tests:
 	-rm -rf sierra2mlir/tests/comparison/**/*.sierra
 	-rm -rf sierra2mlir/tests/comparison/out/*.ll
 	-rm -rf sierra2mlir/tests/comparison/out/*.mlir
+	-rm -rf sierra2mlir/tests/comparison/out/*.out
 
 clean: clean-examples clean-tests
 

--- a/sierra2mlir/benches/cairo.rs
+++ b/sierra2mlir/benches/cairo.rs
@@ -1,9 +1,12 @@
+use std::{fs, path::Path, sync::Arc};
+
+use cairo_lang_compiler::CompilerConfig;
 use cairo_lang_runner::{SierraCasmRunner, StarknetState};
-use cairo_lang_sierra::ProgramParser;
+use cairo_lang_sierra::{program::Program, ProgramParser};
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 
 fn benchmark_cairo(c: &mut Criterion) {
-    let program = ProgramParser::new().parse(include_str!("programs/fib.sierra")).unwrap();
+    let program = compile_sierra_program("fib");
     let runner =
         SierraCasmRunner::new(program, Some(Default::default()), Default::default()).unwrap();
     let starknet_state: StarknetState = Default::default();
@@ -21,3 +24,26 @@ fn benchmark_cairo(c: &mut Criterion) {
 
 criterion_group!(benches, benchmark_cairo);
 criterion_main!(benches);
+
+fn compile_sierra_program(program_name: &str) -> Program {
+    let test_path = Path::new(".").join("benches").join("programs").join(program_name);
+    let sierra_path = test_path.with_extension("sierra");
+    let cairo_path = test_path.with_extension("cairo");
+
+    if sierra_path.exists() {
+        let sierra_code =
+            fs::read_to_string(format!("./benches/programs/{program_name}.sierra")).unwrap();
+        ProgramParser::new().parse(&sierra_code).unwrap()
+    } else if cairo_path.exists() {
+        let program_ptr = cairo_lang_compiler::compile_cairo_project_at_path(
+            &cairo_path,
+            CompilerConfig { replace_ids: true, ..Default::default() },
+        )
+        .expect("Cairo compilation failed");
+        let program = Arc::try_unwrap(program_ptr).unwrap();
+        fs::write(sierra_path, program.to_string()).unwrap();
+        program
+    } else {
+        panic!("Cannot find {program_name}.sierra or {program_name}.cairo")
+    }
+}

--- a/sierra2mlir/src/compiler/external_funcs.rs
+++ b/sierra2mlir/src/compiler/external_funcs.rs
@@ -162,7 +162,7 @@ impl<'ctx> Compiler<'ctx> {
 
         self.op_llvm_store(block, fmt_data.result(0)?.into(), addr)?;
 
-        let target_fd = self.op_u32_const(block, "1");
+        let target_fd = self.op_u32_const(block, &self.print_fd.to_string());
 
         let mut args = vec![target_fd.result(0)?.into(), addr];
         args.extend(values);

--- a/sierra2mlir/tests/comparison/out/.gitignore
+++ b/sierra2mlir/tests/comparison/out/.gitignore
@@ -1,2 +1,3 @@
 *.mlir
 *.ll
+*.out


### PR DESCRIPTION
Changes the tests so they don't depend on lli, which has problems piping the output, rather using the execution engine from mlir with the passed file descriptor.

As far as i tested, this fixes the tests failing sometimes.