### PR TITLE
Add benchmarking examples.

### DIFF
--- a/examples/compare_arrays_200000.cairo
+++ b/examples/compare_arrays_200000.cairo
@@ -1,0 +1,75 @@
+// from starkware.cairo.common.bool import TRUE, FALSE
+// from starkware.cairo.common.alloc import alloc
+
+// func compare_arrays(array_a: felt*, array_b: felt*, array_length: felt, iterator: felt) -> (
+//     r: felt
+// ) {
+//     if (iterator == array_length) {
+//         return (TRUE,);
+//     }
+//     if (array_a[iterator] != array_b[iterator]) {
+//         return (FALSE,);
+//     }
+//     return compare_arrays(array_a, array_b, array_length, iterator + 1);
+// }
+
+// func fill_array(array: felt*, base: felt, step: felt, array_length: felt, iterator: felt) {
+//     if (iterator == array_length) {
+//         return ();
+//     }
+//     assert array[iterator] = base + step * iterator;
+//     return fill_array(array, base, step, array_length, iterator + 1);
+// }
+
+// func main() {
+//     alloc_locals;
+//     tempvar array_length = 250000;
+//     let (array_a: felt*) = alloc();
+//     let (array_b: felt*) = alloc();
+//     fill_array(array_a, 7, 3, array_length, 0);
+//     fill_array(array_b, 7, 3, array_length, 0);
+//     let result: felt = compare_arrays(array_a, array_b, array_length, 0);
+//     assert result = TRUE;
+//     return ();
+// }
+
+use array::ArrayTrait;
+use traits::Into;
+
+fn compare_arrays(
+    data_a: Span<felt252>, data_b: Span<felt252>, array_length: u32, iterator: u32
+) -> bool {
+    if iterator == array_length {
+        return true;
+    }
+
+    if *data_a[iterator] != *data_b[iterator] {
+        return false;
+    }
+
+    compare_arrays(data_a, data_b, array_length, iterator + 1)
+}
+
+fn fill_array(
+    ref data: Array<felt252>, base: felt252, step: felt252, array_length: u32, iterator: u32
+) {
+    if iterator == array_length {
+        return ();
+    }
+
+    data.append(base + step * iterator.into());
+    fill_array(ref data, base, step, array_length, iterator + 1);
+}
+
+fn main() {
+    let array_length = 200000;
+
+    let mut array_a = ArrayTrait::<felt252>::new();
+    let mut array_b = ArrayTrait::<felt252>::new();
+
+    fill_array(ref array_a, 7, 3, array_length, 0);
+    fill_array(ref array_b, 7, 3, array_length, 0);
+
+    let result = compare_arrays(array_a.span(), array_b.span(), array_length, 0);
+    assert(result == true, 'Arrays are not equal');
+}

--- a/examples/factorial_multirun.cairo
+++ b/examples/factorial_multirun.cairo
@@ -1,0 +1,35 @@
+// // factorial(n) =  n!
+// func factorial(n) -> (result: felt) {
+//     if (n == 1) {
+//         return (n,);
+//     }
+//     let (a) = factorial(n - 1);
+//     return (n * a,);
+// }
+//
+// func main() {
+//     // Make sure the factorial(10) == 3628800
+//     let (y) = factorial(10);
+//     y = 3628800;
+//
+//     factorial(2000000);
+//     return ();
+// }
+
+use debug::PrintTrait;
+
+fn factorial(n: felt252) -> felt252 {
+    if (n == 1) {
+        n
+    } else {
+        n * factorial(n - 1)
+    }
+}
+
+#[test]
+fn main() -> felt252 {
+    // Make sure that factorial(10) == 3628800
+    let y: felt252 = factorial(10);
+    assert(3628800 == y, 'failed test');
+    factorial(10000)
+}

--- a/examples/fibonacci_1000_multirun.cairo
+++ b/examples/fibonacci_1000_multirun.cairo
@@ -1,0 +1,26 @@
+// func main() {
+//     fib(1, 1, 1500000);
+//
+//     ret;
+// }
+//
+// func fib(first_element, second_element, n) -> (res: felt) {
+//     if (n == 0) {
+//         return (second_element,);
+//     }
+//
+//     tempvar y = first_element + second_element;
+//     return fib(second_element, y, n - 1);
+// }
+
+fn fib(a: felt252, b: felt252, n: felt252) -> felt252 {
+    match n {
+        0 => a,
+        _ => fib(b, a + b, n - 1),
+    }
+}
+
+#[test]
+fn main() -> felt252 {
+    fib(1, 1, 15000)
+}

--- a/sierra2mlir/src/libfuncs/mod.rs
+++ b/sierra2mlir/src/libfuncs/mod.rs
@@ -43,6 +43,7 @@ impl<'ctx> Compiler<'ctx> {
                 | "get_builtin_costs"
                 | "revoke_ap_tracking"
                 | "disable_ap_tracking"
+                | "enable_ap_tracking"
                 | "u128_mul_guarantee_verify" // output is range check, so it's a noop for us.
                 | "drop"
                 | "jump"


### PR DESCRIPTION
# Add benchmarking examples

## Description

  - Add example `compare_arrays_200000.cairo`.
  - Add example `factorial_multirun.cairo`.
  - Add example `fibonacci_1000_multirun.cairo`.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
