### PR TITLE
Fix benchmarking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,8 +78,7 @@ compile-ll-opt: $(LLVM_OPT_TARGETS)
 bench-ci:
 	cargo bench
 
-bench:
-	@test -n "$(S2M_BENCH_CAIRO_RUNNER)" # S2M_BENCH_CAIRO_RUNNER needs to exist
+bench: build
 	./scripts/comparison.sh
 	cargo bench
 

--- a/Makefile
+++ b/Makefile
@@ -76,11 +76,11 @@ compile-ll: $(LLVM_TARGETS)
 compile-ll-opt: $(LLVM_OPT_TARGETS)
 
 bench-ci:
-	cargo bench
+	cargo criterion
 
 bench: build
 	./scripts/comparison.sh
-	cargo bench
+	cargo criterion
 
 clean-examples:
 	-rm -rf examples/*.ll examples/*.mlir examples/*.sierra

--- a/README.md
+++ b/README.md
@@ -88,8 +88,7 @@ Options:
 
 You need to setup some environment variables:
 ```bash
-$S2M_BENCH_CAIRO_RUNNER=/path/to/cairo-run
-$MLIR_SYS_160_PREFIX=/path/to/llvm16
+$MLIR_SYS_160_PREFIX=/path/to/llvm16  # Required for non-standard LLVM install locations.
 ```
 
 ```bash

--- a/scripts/comparison.sh
+++ b/scripts/comparison.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
 # config vars
-cairo_run=$S2M_BENCH_CAIRO_RUNNER
 sierra2mlir_cli=./target/release/cli
 llvm_dir=$MLIR_SYS_160_PREFIX
 bench_results=./bench-results
@@ -13,41 +12,41 @@ ENDCOLOR="\e[0m"
 mkdir -p $bench_results
 
 # bench programs
-for sierra_program in ./sierra2mlir/benches/programs/*.sierra; do
+for program_source in ./sierra2mlir/benches/programs/*.cairo; do
 	echo '--------------------'
-	echo -e "${RED}BENCHMARKING FILE${ENDCOLOR}: ${GREEN}$sierra_program${ENDCOLOR}"
+	echo -e "${RED}BENCHMARKING FILE${ENDCOLOR}: ${GREEN}$program_source${ENDCOLOR}"
 	echo '>>>>>>>>>>>>>>>>>>>>'
-	program="$(basename "$sierra_program" sierra)"
-	filename=$(basename -- "$sierra_program")
+	program="$(basename "$program_source" cairo)"
+	filename=$(basename -- "$program_source")
 	filename="${filename%.*}"
-	$sierra2mlir_cli compile "$sierra_program" -m --available-gas 9000000000 -o $bench_results/"$filename".mlir
+	$sierra2mlir_cli compile "$program_source" -m --available-gas 9000000000 -o $bench_results/"$filename".mlir
 	"$llvm_dir"/bin/mlir-translate --mlir-to-llvmir $bench_results/"$filename".mlir -o $bench_results/"$filename".ll
 	"$llvm_dir"/bin/clang $bench_results/"$filename".ll -Wno-override-module -L"$llvm_dir"/lib -L"./target/release/" \
 		-lsierra2mlir_utils -lmlir_c_runner_utils -Wl,-rpath "$llvm_dir"/lib \
 		-Wl,-rpath "./target/release/" -o $bench_results/"$filename".bin
 	hyperfine -N -i --warmup 3 \
-			"$cairo_run --available-gas 9000000000 sierra2mlir/benches/programs/${program}cairo" \
-			"$sierra2mlir_cli run --available-gas 9000000000 $sierra_program -m -f main" \
+			"cairo-run --available-gas 9000000000 sierra2mlir/benches/programs/${program}cairo" \
+			"$sierra2mlir_cli run --available-gas 9000000000 $program_source -m -f main" \
 			"$bench_results/$filename".bin
 	echo '<<<<<<<<<<<<<<<<<<<'
 done
 
 # example programs
-for sierra_program in ./examples/*.sierra; do
+for program_source in ./examples/*.cairo; do
 	echo '--------------------'
-	echo -e "${RED}BENCHMARKING FILE${ENDCOLOR}: ${GREEN}$sierra_program${ENDCOLOR}"
+	echo -e "${RED}BENCHMARKING FILE${ENDCOLOR}: ${GREEN}$program_source${ENDCOLOR}"
 	echo '>>>>>>>>>>>>>>>>>>>>'
-	program="$(basename "$sierra_program" sierra)"
-	filename=$(basename -- "$sierra_program")
+	program="$(basename "$program_source" cairo)"
+	filename=$(basename -- "$program_source")
 	filename="${filename%.*}"
-	$sierra2mlir_cli compile "$sierra_program" -m --available-gas 9000000000 -o $bench_results/"$filename".mlir
+	$sierra2mlir_cli compile "$program_source" -m --available-gas 9000000000 -o $bench_results/"$filename".mlir
 	"$llvm_dir"/bin/mlir-translate --mlir-to-llvmir $bench_results/"$filename".mlir -o $bench_results/"$filename".ll
 	"$llvm_dir"/bin/clang $bench_results/"$filename".ll -Wno-override-module -L"$llvm_dir"/lib -L"./target/release/" \
 		-lsierra2mlir_utils -lmlir_c_runner_utils -Wl,-rpath "$llvm_dir"/lib \
 		-Wl,-rpath "./target/release/" -o $bench_results/"$filename".bin
 	hyperfine -N -i --warmup 3 \
-			"$cairo_run --available-gas 9000000000 examples/${program}cairo" \
-			"$sierra2mlir_cli run --available-gas 9000000000 $sierra_program -m -f main" \
+			"cairo-run --available-gas 9000000000 examples/${program}cairo" \
+			"$sierra2mlir_cli run --available-gas 9000000000 $program_source -m -f main" \
 			"$bench_results/$filename".bin
 	echo '<<<<<<<<<<<<<<<<<<<'
 done


### PR DESCRIPTION
# Fix benchmarking

## Description

  - Remove `cairo-run` env var.
  - Use `.cairo` for benchmarking instead of `.sierra` (due to the sierra parser bug).
  - Run `make build` before benchmarking to update the binaries.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
