### PR TITLE
Update `cairo-lang-*` dependencies version to `1.1.0`.

### DIFF
--- a/.github/scripts/check-git-deps.sh
+++ b/.github/scripts/check-git-deps.sh
@@ -12,7 +12,7 @@ latest_release=$(
   )
 
 current_release=$(
-    rg 'cairo-lang-sierra\s*=\s*\{\s*git\s*=\s*"https://github.com/starkware-libs/cairo",\s*tag = "(.*?)"\s*\}' sierra2mlir/Cargo.toml -r '$1'
+    rg 'cairo-lang-sierra\s*=\s*(?:\{\s*git\s*=\s*"https://github.com/starkware-libs/cairo",\s*tag = "(.*?)"\s*\}|"(.*?)")' sierra2mlir/Cargo.toml -r '$1$2'
 )
 
 current_release_line=$(echo $current_release | cut -d':' -f1)

--- a/.github/scripts/check-git-deps.sh
+++ b/.github/scripts/check-git-deps.sh
@@ -18,6 +18,10 @@ current_release=$(
 current_release_line=$(echo $current_release | cut -d':' -f1)
 current_release_str=$(echo $current_release | cut -d':' -f2)
 
-if [ "$current_release_str" != "$latest_release" ]; then
+# Strip `v` prefix.
+$current_release_str=$(echo $current_release_str | tr -d v)
+$latest_release=$(echo $latest_release | tr -d v)
+
+if [ "$current_release_str" != "$latest_release" && "v$current_release_str" != "$latest_release" ]; then
     echo "::warning file=sierra2mlir/Cargo.toml,line=$current_release_line,endLine=$current_release_line,title=Outdated cairo dependency::Current release = $current_release_str, Upstream release = $latest_release"
 fi

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-cairo-lang-compiler = { git = "https://github.com/starkware-libs/cairo", tag = "v1.1.0-rc0" }
-cairo-lang-sierra = { git = "https://github.com/starkware-libs/cairo", tag = "v1.1.0-rc0" }
+cairo-lang-compiler = "1.1.0"
+cairo-lang-sierra = "1.1.0"
 clap = { version = "4.1.13", features = ["derive"] }
 color-eyre = "0.6.2"
 sierra2mlir = { version = "0.1.0", path = "../sierra2mlir" }

--- a/scripts/fetch-corelibs.sh
+++ b/scripts/fetch-corelibs.sh
@@ -5,7 +5,7 @@ set -e
 
 git clone \
     --depth 1 \
-    --branch v1.1.0-rc0 \
+    --branch v1.1.0 \
     https://github.com/starkware-libs/cairo.git \
     starkware-cairo
 

--- a/sierra2mlir/Cargo.toml
+++ b/sierra2mlir/Cargo.toml
@@ -15,12 +15,12 @@ name = "sierra2mlir"
 harness = false
 
 [dependencies]
-cairo-lang-compiler = { git = "https://github.com/starkware-libs/cairo", tag = "v1.1.0-rc0" }
-cairo-lang-sierra = { git = "https://github.com/starkware-libs/cairo", tag = "v1.1.0-rc0" }
-cairo-lang-sierra-gas = { git = "https://github.com/starkware-libs/cairo", tag = "v1.1.0-rc0" }
-cairo-lang-sierra-to-casm = { git = "https://github.com/starkware-libs/cairo", tag = "v1.1.0-rc0" }
-cairo-lang-sierra-ap-change = { git = "https://github.com/starkware-libs/cairo", tag = "v1.1.0-rc0" }
-cairo-lang-utils = { git = "https://github.com/starkware-libs/cairo", tag = "v1.1.0-rc0" }
+cairo-lang-compiler = "1.1.0"
+cairo-lang-sierra = "1.1.0"
+cairo-lang-sierra-gas = "1.1.0"
+cairo-lang-sierra-to-casm = "1.1.0"
+cairo-lang-sierra-ap-change = "1.1.0"
+cairo-lang-utils = "1.1.0"
 cfg-match = "0.2.1"
 color-eyre = "0.6.2"
 itertools = "0.10.5"
@@ -33,7 +33,7 @@ tracing = "0.1.37"
 
 [dev-dependencies]
 cairo-felt = "0.3.0-rc1"
-cairo-lang-runner = { git = "https://github.com/starkware-libs/cairo", tag = "v1.1.0-rc0" }
+cairo-lang-runner = "1.1.0"
 cairo-vm = "0.3.0-rc1"
 criterion = "0.5.0"
 test-case = "3.0.0"


### PR DESCRIPTION
# Update cairo to version 1.1.0

## Description

  - Update `cairo-lang-compiler` in the CLI to 1.1.0.
  - Update `cairo-lang-sierra` in the CLI to 1.1.0.
  - Update `cairo-lang-compiler` in the compiler to 1.1.0.
  - Update `cairo-lang-sierra` in the compiler to 1.1.0.
  - Update `cairo-lang-sierra-gas` in the compiler to 1.1.0.
  - Update `cairo-lang-to-casm` in the compiler to 1.1.0.
  - Update `cairo-lang-ap-change` in the compiler to 1.1.0.
  - Update `cairo-lang-utils` in the compiler to 1.1.0.
  - Update `cairo-lang-runner` in the compiler to 1.1.0.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
