### PR TITLE
fix hyperfine bench script

### DIFF
--- a/scripts/bench-hyperfine.sh
+++ b/scripts/bench-hyperfine.sh
@@ -57,6 +57,8 @@ run_bench() {
         -L "target/release" \
         -lmlir_c_runner_utils \
         -lsierra2mlir_utils \
+        -Wl,-rpath "$MLIR_DIR/lib" \
+        -Wl,-rpath "target/release" \
         -o "$OUTPUT_DIR/$base_name" \
         >> /dev/stderr
 


### PR DESCRIPTION
The MLIR bench failed due to not loading libraries at runtime
